### PR TITLE
Add formatted Telegram messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+news_state.json
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # MOEX News Parser
 
-This repository contains a simple parser that retrieves news from [nsddata.ru](https://nsddata.ru/ru/news) and posts updates to a Telegram channel.
+This repository contains a simple parser that retrieves news from
+[nsddata.ru](https://nsddata.ru/ru/news) and posts updates to a Telegram channel.
 
 The parser filters news items by keywords `DVCA`, `INTR` and `REDM` and publishes matching events.
 
@@ -30,7 +31,8 @@ To change the keywords, pass them with `--keyword`:
 python scripts/parse_nsd_news.py --keyword dvca --keyword intr
 ```
 
-The script remembers the last processed news ID in `news_state.json` to avoid sending duplicates.
+The script remembers the last processed news ID in `news_state.json` to avoid
+sending duplicates.
 
 Each message is formatted like:
 
@@ -50,5 +52,6 @@ To confirm that the Telegram token is available in the environment run:
 python - <<'PY'
 import os
 print("TOKEN_PRESENT", bool(os.getenv("TELEGRAM_BOT_TOKEN")))
+print("CHAT_PRESENT", bool(os.getenv("TELEGRAM_CHAT_ID")))
 PY
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# MOEX
+# MOEX News Parser
+
+This repository contains a simple parser that retrieves news from [nsddata.ru](https://nsddata.ru/ru/news) and posts updates to a Telegram channel.
+
+The parser filters news items by keywords `DVCA`, `INTR` and `REDM` and publishes matching events.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Create two environment variables with your Telegram credentials:
+
+- `TELEGRAM_BOT_TOKEN` – token of your Telegram bot.
+- `TELEGRAM_CHAT_ID` – identifier of the chat or channel where messages will be sent.
+
+
+3. Run the parser:
+
+```bash
+python scripts/parse_nsd_news.py
+```
+
+To change the keywords, pass them with `--keyword`:
+
+```bash
+python scripts/parse_nsd_news.py --keyword dvca --keyword intr
+```
+
+The script remembers the last processed news ID in `news_state.json` to avoid sending duplicates.
+
+Each message is formatted like:
+
+```
+💰 Дивиденды (DVCA)
+📅 Дата: 28.06.2025
+📋 Описание: Об отмене корпоративного действия "Выплата дивидендов в виде денежных средств" с ценными бумагами эмитента ПАО "ФосАгро" ИНН 7736216869
+🏢 ИНН: 7736216869
+📊 ISIN: RU000A0JRKT8
+```
+
+## Quick test
+
+To confirm that the Telegram token is available in the environment run:
+
+```bash
+python - <<'PY'
+import os
+print("TOKEN_PRESENT", bool(os.getenv("TELEGRAM_BOT_TOKEN")))
+PY
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4

--- a/scripts/parse_nsd_news.py
+++ b/scripts/parse_nsd_news.py
@@ -1,0 +1,133 @@
+"""Fetch and post NSD news to Telegram."""
+
+import os
+import json
+import re
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+import requests
+from bs4 import BeautifulSoup
+
+URL = "https://nsddata.ru/ru/news"
+STATE_FILE = Path(__file__).with_name("news_state.json")
+DEFAULT_KEYWORDS = ["dvca", "intr", "redm"]
+
+# Mapping of corporate action codes to Russian names and emojis
+CA_MAP = {
+    "dvca": ("Дивиденды", "\U0001F4B0"),
+    "intr": ("Купон", "\U0001F4C8"),
+    "redm": ("Погашение", "\U0001F4C9"),
+}
+
+
+def fetch_page() -> str:
+    """Return the HTML of the NSD news page."""
+    headers = {"User-Agent": "Mozilla/5.0"}
+    resp = requests.get(URL, timeout=30, headers=headers)
+    resp.raise_for_status()
+    return resp.text
+
+
+def parse_news(html: str, keywords: Iterable[str]) -> List[Tuple[int, str, str, str]]:
+    """Parse news items matching *keywords* from HTML."""
+    soup = BeautifulSoup(html, "html.parser")
+    items = soup.select(".news_list__item")
+    news: List[Tuple[int, str, str, str]] = []
+    for item in items:
+        date_div = item.select_one(".news_list__item__date")
+        title_link = item.select_one(".news_list__item__header__title")
+        if not date_div or not title_link:
+            continue
+        date = date_div.get_text(strip=True)
+        text = title_link.get_text(strip=True)
+        link = "https://nsddata.ru" + title_link["href"]
+        match = re.search(r"/view/(\d+)", title_link["href"])
+        news_id = int(match.group(1)) if match else 0
+        if any(k.lower() in text.lower() for k in keywords):
+            news.append((news_id, date, text, link))
+    return news
+
+
+def load_state() -> int:
+    """Return the last processed news ID or ``0`` if none is stored."""
+    try:
+        with open(STATE_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return int(data.get("last_id", 0))
+    except FileNotFoundError:
+        return 0
+
+
+def save_state(last_id: int) -> None:
+    """Persist the last processed news ID."""
+    with open(STATE_FILE, "w", encoding="utf-8") as f:
+        json.dump({"last_id": last_id}, f)
+
+
+def format_message(date: str, text: str, link: str) -> str:
+    """Return a formatted Telegram message."""
+    ca_match = re.match(r"\(([^)]+)\)\s*\(([^)]+)\)\s*(.+)", text)
+    abbr = ca_match.group(1) if ca_match else ""
+    descr = ca_match.group(3) if ca_match else text
+    abbr_lower = abbr.lower()
+    name, emoji = CA_MAP.get(abbr_lower, (abbr, "\U0001F4CB"))
+    inn_match = re.search(r"\b(\d{10}|\d{12})\b", text)
+    inn = inn_match.group(1) if inn_match else "-"
+    isin_match = re.search(r"\b[A-Z0-9]{12}\b", text)
+    isin = isin_match.group(0) if isin_match else "-"
+    return (
+        f"{emoji} {name} ({abbr})\n"
+        f"\U0001F4C5 Дата: {date}\n"
+        f"\U0001F4CB Описание: {descr}\n"
+        f"\U0001F3E2 ИНН: {inn}\n"
+        f"\U0001F4CA ISIN: {isin}\n"
+        f"{link}"
+    )
+
+
+def send_telegram(text: str) -> None:
+    """Send *text* to the configured Telegram chat."""
+    token = os.environ.get("TELEGRAM_BOT_TOKEN")
+    chat_id = os.environ.get("TELEGRAM_CHAT_ID")
+    if not token or not chat_id:
+        raise RuntimeError("Telegram credentials are not set")
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    payload = {"chat_id": chat_id, "text": text}
+    resp = requests.post(url, data=payload, timeout=30)
+    resp.raise_for_status()
+
+
+def main(keywords: Iterable[str] = DEFAULT_KEYWORDS) -> None:
+    """Fetch and publish NSD news matching *keywords*."""
+    html = fetch_page()
+    news = parse_news(html, keywords)
+    if not news:
+        return
+    last_id = load_state()
+    new_last_id = last_id
+    for news_id, date, text, link in sorted(news, key=lambda x: x[0]):
+        if news_id > last_id:
+            message = format_message(date, text, link)
+            send_telegram(message)
+            if news_id > new_last_id:
+                new_last_id = news_id
+    if new_last_id != last_id:
+        save_state(new_last_id)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Post NSD news to Telegram")
+    parser.add_argument(
+        "-k",
+        "--keyword",
+        dest="keywords",
+        action="append",
+        help="keyword to filter news (can be repeated)",
+    )
+    args = parser.parse_args()
+
+    keywords = args.keywords if args.keywords else DEFAULT_KEYWORDS
+    main(keywords)


### PR DESCRIPTION
## Summary
- extend parser to format news with emoji and details
- document the Telegram message format in README

## Testing
- `python -m py_compile scripts/parse_nsd_news.py`
- `TELEGRAM_BOT_TOKEN=123 TELEGRAM_CHAT_ID=456 python scripts/parse_nsd_news.py` *(fails: 404 Client Error)*
- `python - <<'PY'
import os
print('TOKEN_PRESENT', bool(os.getenv('TELEGRAM_BOT_TOKEN')))
PY
`

------
https://chatgpt.com/codex/tasks/task_e_68617cdfa2708324834e1d743eb658d8